### PR TITLE
Update link to CameraStarterKit

### DIFF
--- a/Samples/VideoEffectSample/readme.md
+++ b/Samples/VideoEffectSample/readme.md
@@ -23,7 +23,7 @@ Specifically, this sample will cover how to:
 **Samples**
 
 
-[UniversalCameraSample](https://github.com/Microsoft/Windows-universal-samples/tree/master/universalcamerasample)
+[CameraStarterKit](https://github.com/Microsoft/Windows-universal-samples/tree/master/Samples/CameraStarterKit)
 
 [How to rotate captured video](https://msdn.microsoft.com/en-us/library/windows/apps/hh868174.aspx)
 
@@ -66,7 +66,7 @@ Specifically, this sample will cover how to:
 
 ## Build the sample
 
-1.  Start Visual Studio 2015 and select **File** \> **Open** \> **Project/Solution**.
+1.  Start Visual StudioÂ 2015 and select **File** \> **Open** \> **Project/Solution**.
 2.  Press Ctrl+Shift+B, or select **Build** \> **Build Solution**.
 
 ## Run the sample


### PR DESCRIPTION
The UniversalCameraSample was renamed to CameraStarterKit. Alternatively, a redirection link exists, which _might_ be a little more stable, if something like this were to happen again: http://go.microsoft.com/fwlink/?LinkId=619479
